### PR TITLE
add start_time different from zero to fmpy gui

### DIFF
--- a/fmpy/__init__.py
+++ b/fmpy/__init__.py
@@ -183,8 +183,18 @@ def extract(filename, unzipdir=None):
         import win32file
         unzipdir = win32file.GetLongPathName(unzipdir)
 
-    # extract the archive
     with zipfile.ZipFile(filename, 'r') as zf:
+
+        # check filenames
+        for name in zf.namelist():
+            
+            if '\\' in name:
+                raise Exception("Illegal path %s found in %s. All slashes must be forward slashes." % (name, filename))
+
+            if ':' in name or name.startswith('/'):
+                raise Exception("Illegal path %s found in %s. The path must not contain a drive or device letter, or a leading slash." % (name, filename))
+
+        # extract the archive
         zf.extractall(unzipdir)
 
     return unzipdir

--- a/fmpy/c-code/fmi3FunctionTypes.h
+++ b/fmpy/c-code/fmi3FunctionTypes.h
@@ -1,0 +1,473 @@
+#ifndef fmi3FunctionTypes_h
+#define fmi3FunctionTypes_h
+
+#include "fmi3PlatformTypes.h"
+
+/*
+This header file must be utilized when compiling an FMU or an FMI master.
+It declares data and function types for FMI 3.0-wg003.3
+
+Copyright (C) 2011 MODELISAR consortium,
+              2012-2019 Modelica Association Project "FMI"
+              All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* make sure all compiler use the same alignment policies for structures */
+#if defined _MSC_VER || defined __GNUC__
+#pragma pack(push,8)
+#endif
+
+/* Include stddef.h, in order that size_t etc. is defined */
+#include <stddef.h>
+
+
+/* Type definitions */
+
+/* tag::Status[] */
+typedef enum {
+    fmi3OK,
+    fmi3Warning,
+    fmi3Discard,
+    fmi3Error,
+    fmi3Fatal,
+    fmi3Pending
+} fmi3Status;
+/* end::Status[] */
+
+/* tag::InterfaceType[] */
+typedef enum {
+    fmi3ModelExchange,
+    fmi3CoSimulation
+} fmi3InterfaceType;
+/* end::InterfaceType[] */
+
+/* tag::DependencyKind[] */
+typedef enum {
+    /* fmi3Independent = 0, not needed but reserved for future use */
+    fmi3Constant  = 1,
+    fmi3Fixed     = 2,
+    fmi3Tunable   = 3,
+    fmi3Discrete  = 4,
+    fmi3Dependent = 5
+} fmi3DependencyKind;
+/* end::DependencyKind[] */
+
+/* tag::CallbackFunctions[] */
+typedef void  (*fmi3CallbackLogMessage)     (fmi3InstanceEnvironment instanceEnvironment,
+                                             fmi3String instanceName,
+                                             fmi3Status status,
+                                             fmi3String category,
+                                             fmi3String message);
+typedef void* (*fmi3CallbackAllocateMemory) (fmi3InstanceEnvironment instanceEnvironment,
+                                             size_t nobj,
+                                             size_t size);
+typedef void  (*fmi3CallbackFreeMemory)     (fmi3InstanceEnvironment instanceEnvironment,
+                                             void* obj);
+typedef void  (*fmi3CallbackStepFinished)   (fmi3InstanceEnvironment instanceEnvironment,
+                                             fmi3Status status);
+
+typedef struct {
+    fmi3CallbackLogMessage     logMessage;
+    fmi3CallbackAllocateMemory allocateMemory;
+    fmi3CallbackFreeMemory     freeMemory;
+    fmi3CallbackStepFinished   stepFinished;
+    fmi3InstanceEnvironment    instanceEnvironment;
+} fmi3CallbackFunctions;
+/* end::CallbackFunctions[] */
+
+/* tag::EventInfo[] */
+typedef struct {
+    fmi3Boolean newDiscreteStatesNeeded;
+    fmi3Boolean terminateSimulation;
+    fmi3Boolean nominalsOfContinuousStatesChanged;
+    fmi3Boolean valuesOfContinuousStatesChanged;
+    fmi3Boolean nextEventTimeDefined;
+    fmi3Float64 nextEventTime;  /* next event if nextEventTimeDefined=fmi3True */
+} fmi3EventInfo;
+/* end::EventInfo[] */
+
+/* reset alignment policy to the one set before reading this file */
+#if defined _MSC_VER || defined __GNUC__
+#pragma pack(pop)
+#endif
+
+/* Define fmi3 function pointer types to simplify dynamic loading */
+
+/***************************************************
+Types for Common Functions
+****************************************************/
+
+/* Inquire version numbers and setting logging status */
+
+/* tag::GetVersion[] */
+typedef const char* fmi3GetVersionTYPE(void);
+/* end::GetVersion[] */
+
+/* tag::SetDebugLogging[] */
+typedef fmi3Status  fmi3SetDebugLoggingTYPE(fmi3Instance instance,
+                                            fmi3Boolean loggingOn,
+                                            size_t nCategories,
+                                            const fmi3String categories[]);
+/* end::SetDebugLogging[] */
+
+/* Creation and destruction of FMU instances and setting debug status */
+/* tag::Instantiate[] */
+typedef fmi3Instance fmi3InstantiateTYPE(fmi3String        instanceName,
+                                         fmi3InterfaceType fmuType,
+                                         fmi3String        fmuInstantiationToken,
+                                         fmi3String        fmuResourceLocation,
+                                         const fmi3CallbackFunctions* functions,
+                                         fmi3Boolean       visible,
+                                         fmi3Boolean       loggingOn);
+/* end::Instantiate[] */
+
+/* tag::FreeInstance[] */
+typedef void fmi3FreeInstanceTYPE(fmi3Instance instance);
+/* end::FreeInstance[] */
+
+/* Enter and exit initialization mode, terminate and reset */
+/* tag::SetupExperiment[] */
+typedef fmi3Status fmi3SetupExperimentTYPE(fmi3Instance instance,
+                                           fmi3Boolean toleranceDefined,
+                                           fmi3Float64 tolerance,
+                                           fmi3Float64 startTime,
+                                           fmi3Boolean stopTimeDefined,
+                                           fmi3Float64 stopTime);
+/* end::SetupExperiment[] */
+
+/* tag::EnterInitializationMode[] */
+typedef fmi3Status fmi3EnterInitializationModeTYPE(fmi3Instance instance);
+/* end::EnterInitializationMode[] */
+
+/* tag::ExitInitializationMode[] */
+typedef fmi3Status fmi3ExitInitializationModeTYPE(fmi3Instance instance);
+/* end::ExitInitializationMode[] */
+
+/* tag::Terminate[] */
+typedef fmi3Status fmi3TerminateTYPE(fmi3Instance instance);
+/* end::Terminate[] */
+
+/* tag::Reset[] */
+typedef fmi3Status fmi3ResetTYPE(fmi3Instance instance);
+/* end::Reset[] */
+
+/* Getting and setting variable values */
+/* tag::Getters[] */
+typedef fmi3Status fmi3GetFloat32TYPE(fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3Float32 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetFloat64TYPE(fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3Float64 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetInt8TYPE   (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3Int8 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetUInt8TYPE  (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3UInt8 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetInt16TYPE  (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3Int16 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetUInt16TYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3UInt16 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetInt32TYPE  (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3Int32 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetUInt32TYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3UInt32 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetInt64TYPE  (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3Int64 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetUInt64TYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3UInt64 values[], size_t nValues);
+
+typedef fmi3Status fmi3GetBooleanTYPE(fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3Boolean values[], size_t nValues);
+
+typedef fmi3Status fmi3GetStringTYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      fmi3String values[], size_t nValues);
+
+typedef fmi3Status fmi3GetBinaryTYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      size_t sizes[], fmi3Binary values[], size_t nValues);
+/* end::Getters[] */
+
+/* tag::Setters[] */
+typedef fmi3Status fmi3SetFloat32TYPE(fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3Float32 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetFloat64TYPE(fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3Float64 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetInt8TYPE   (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3Int8 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetUInt8TYPE  (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3UInt8 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetInt16TYPE  (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3Int16 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetUInt16TYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3UInt16 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetInt32TYPE  (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3Int32 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetUInt32TYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3UInt32 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetInt64TYPE  (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3Int64 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetUInt64TYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3UInt64 values[], size_t nValues);
+
+typedef fmi3Status fmi3SetBooleanTYPE(fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3Boolean values[], size_t nValues);
+
+typedef fmi3Status fmi3SetStringTYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const fmi3String values[], size_t nValues);
+
+typedef fmi3Status fmi3SetBinaryTYPE (fmi3Instance instance,
+                                      const fmi3ValueReference valueReferences[], size_t nValueReferences,
+                                      const size_t sizes[], const fmi3Binary values[], size_t nValues);
+/* end::Setters[] */
+
+/* Getting Variable Dependency Information */
+
+/* tag::GetNumberOfVariableDependencies[] */
+typedef fmi3Status fmi3GetNumberOfVariableDependenciesTYPE(fmi3Instance instance,
+                                                           fmi3ValueReference valueReference,
+                                                           size_t* nDependencies);
+/* end::GetNumberOfVariableDependencies[] */
+
+/* tag::GetVariableDependencies[] */
+typedef fmi3Status fmi3GetVariableDependenciesTYPE(fmi3Instance instance,
+                                                   fmi3ValueReference dependent,
+                                                   size_t elementIndicesOfDependent[],
+                                                   fmi3ValueReference independents[],
+                                                   size_t elementIndicesOfIndependents[],
+                                                   fmi3DependencyKind dependencyKinds[],
+                                                   size_t nDependencies);
+/* end::GetVariableDependencies[] */
+
+/* Getting and setting the internal FMU state */
+
+/* tag::GetSetFreeFMUState[] */
+typedef fmi3Status fmi3GetFMUStateTYPE (fmi3Instance instance, fmi3FMUState* FMUState);
+typedef fmi3Status fmi3SetFMUStateTYPE (fmi3Instance instance, fmi3FMUState  FMUState);
+typedef fmi3Status fmi3FreeFMUStateTYPE(fmi3Instance instance, fmi3FMUState* FMUState);
+/* end::GetSetFreeFMUState[] */
+
+/* tag::SerializedFMUState[] */
+typedef fmi3Status fmi3SerializedFMUStateSizeTYPE(fmi3Instance instance,
+                                                  fmi3FMUState  FMUState,
+                                                  size_t* size);
+
+typedef fmi3Status fmi3SerializeFMUStateTYPE     (fmi3Instance instance,
+                                                  fmi3FMUState  FMUState,
+                                                  fmi3Byte serializedState[],
+                                                  size_t size);
+
+typedef fmi3Status fmi3DeSerializeFMUStateTYPE   (fmi3Instance instance,
+                                                  const fmi3Byte serializedState[],
+                                                  size_t size,
+                                                  fmi3FMUState* FMUState);
+/* end::SerializedFMUState[] */
+
+/* Getting partial derivatives */
+
+/* tag::GetDirectionalDerivative[] */
+typedef fmi3Status fmi3GetDirectionalDerivativeTYPE(fmi3Instance instance,
+                                                    const fmi3ValueReference unknowns[],
+                                                    size_t nUnknowns,
+                                                    const fmi3ValueReference knowns[],
+                                                    size_t nKnowns,
+                                                    const fmi3Float64 deltaKnowns[],
+                                                    size_t nDeltaKnowns,
+                                                    fmi3Float64 deltaUnknowns[],
+                                                    size_t nDeltaOfUnknowns);
+/* end::GetDirectionalDerivative[] */
+
+/***************************************************
+Types for Functions for FMI3 for Model Exchange
+****************************************************/
+
+/* Enter and exit the different modes */
+
+/* tag::EnterEventMode[] */
+typedef fmi3Status fmi3EnterEventModeTYPE(fmi3Instance instance);
+/* end::EnterEventMode[] */
+
+/* tag::NewDiscreteStates[] */
+typedef fmi3Status fmi3NewDiscreteStatesTYPE(fmi3Instance instance,
+                                             fmi3EventInfo* eventInfo);
+/* end::NewDiscreteStates[] */
+
+/* tag::EnterContinuousTimeMode[] */
+typedef fmi3Status fmi3EnterContinuousTimeModeTYPE(fmi3Instance instance);
+/* end::EnterContinuousTimeMode[] */
+
+/* tag::CompletedIntegratorStep[] */
+typedef fmi3Status fmi3CompletedIntegratorStepTYPE(fmi3Instance instance,
+                                                   fmi3Boolean noSetFMUStatePriorToCurrentPoint,
+                                                   fmi3Boolean* enterEventMode,
+                                                   fmi3Boolean* terminateSimulation);
+/* end::CompletedIntegratorStep[] */
+
+/* Providing independent variables and re-initialization of caching */
+
+/* tag::SetTime[] */
+typedef fmi3Status fmi3SetTimeTYPE(fmi3Instance instance, fmi3Float64 time);
+/* end::SetTime[] */
+
+/* tag::SetContinuousStates[] */
+typedef fmi3Status fmi3SetContinuousStatesTYPE(fmi3Instance instance,
+                                               const fmi3Float64 x[],
+                                               size_t nx);
+/* end::SetContinuousStates[] */
+
+/* Evaluation of the model equations */
+
+/* tag::GetDerivatives[] */
+typedef fmi3Status fmi3GetDerivativesTYPE(fmi3Instance instance,
+                                          fmi3Float64 derivatives[],
+                                          size_t nx);
+/* end::GetDerivatives[] */
+
+/* tag::GetEventIndicators[] */
+typedef fmi3Status fmi3GetEventIndicatorsTYPE(fmi3Instance instance,
+                                              fmi3Float64 eventIndicators[],
+                                              size_t ni);
+/* end::GetEventIndicators[] */
+
+/* tag::GetContinuousStates[] */
+typedef fmi3Status fmi3GetContinuousStatesTYPE(fmi3Instance instance, fmi3Float64 x[], size_t nx);
+/* end::GetContinuousStates[] */
+
+/* tag::GetNominalsOfContinuousStates[] */
+typedef fmi3Status fmi3GetNominalsOfContinuousStatesTYPE(fmi3Instance instance,
+                                                         fmi3Float64 nominals[],
+                                                         size_t nx);
+/* end::GetNominalsOfContinuousStates[] */
+
+/* tag::GetNumberOfEventIndicators[] */
+typedef fmi3Status fmi3GetNumberOfEventIndicatorsTYPE(fmi3Instance instance, size_t* nz);
+/* end::GetNumberOfEventIndicators[] */
+
+/* tag::GetNumberOfContinuousStates[] */
+typedef fmi3Status fmi3GetNumberOfContinuousStatesTYPE(fmi3Instance instance, size_t* nx);
+/* end::GetNumberOfContinuousStates[] */
+
+/***************************************************
+Types for Functions for FMI3 for Co-Simulation
+****************************************************/
+
+/* Simulating the slave */
+
+/* tag::SetInputDerivatives[] */
+typedef fmi3Status fmi3SetInputDerivativesTYPE(fmi3Instance instance,
+                                               const fmi3ValueReference valueReferences[],
+                                               size_t nValueReferences,
+                                               const fmi3Int32 orders[],
+                                               const fmi3Float64 values[],
+                                               size_t nValues);
+/* end::SetInputDerivatives[] */
+
+/* tag::GetOutputDerivatives[] */
+typedef fmi3Status fmi3GetOutputDerivativesTYPE(fmi3Instance instance,
+                                                const fmi3ValueReference valueReferences[],
+                                                size_t nValueReferences,
+                                                const fmi3Int32 orders[],
+                                                fmi3Float64 values[],
+                                                size_t nValues);
+/* end::GetOutputDerivatives[] */
+
+/* tag::DoStep[] */
+typedef fmi3Status fmi3DoStepTYPE(fmi3Instance instance,
+                                  fmi3Float64 currentCommunicationPoint,
+                                  fmi3Float64 communicationStepSize,
+                                  fmi3Boolean noSetFMUStatePriorToCurrentPoint);
+/* end::DoStep[] */
+
+/* tag::CancelStep[] */
+typedef fmi3Status fmi3CancelStepTYPE(fmi3Instance instance);
+/* end::CancelStep[] */
+
+/* Inquire slave status */
+
+/* tag::GetDoStepPendingStatus[] */
+typedef fmi3Status fmi3GetDoStepPendingStatusTYPE(fmi3Instance instance,
+                                                  fmi3Status* status,
+                                                  fmi3String* message);
+/* end::GetDoStepPendingStatus[] */
+
+/* tag::GetDoStepDiscardedStatus[] */
+typedef fmi3Status fmi3GetDoStepDiscardedStatusTYPE(fmi3Instance instance,
+                                                    fmi3Boolean* terminate,
+                                                    fmi3Float64* lastSuccessfulTime);
+/* end::GetDoStepDiscardedStatus[] */
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif /* fmi3FunctionTypes_h */

--- a/fmpy/c-code/fmi3Functions.h
+++ b/fmpy/c-code/fmi3Functions.h
@@ -1,0 +1,282 @@
+#ifndef fmi3Functions_h
+#define fmi3Functions_h
+
+/*
+This header file must be utilized when compiling a FMU.
+It defines all functions of the
+     FMI 3.0-wg003.3 Model Exchange and Co-Simulation Interface.
+
+In order to have unique function names even if several FMUs
+are compiled together (e.g. for embedded systems), every "real" function name
+is constructed by prepending the function name by "FMI3_FUNCTION_PREFIX".
+Therefore, the typical usage is:
+
+  #define FMI3_FUNCTION_PREFIX MyModel_
+  #include "fmi3Functions.h"
+
+As a result, a function that is defined as "fmi3GetDerivatives" in this header file,
+is actually getting the name "MyModel_fmi3GetDerivatives".
+
+This only holds if the FMU is shipped in C source code, or is compiled in a
+static link library. For FMUs compiled in a DLL/sharedObject, the "actual" function
+names are used and "FMI3_FUNCTION_PREFIX" must not be defined.
+
+Copyright (C) 2008-2011 MODELISAR consortium,
+              2012-2019 Modelica Association Project "FMI"
+              All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "fmi3PlatformTypes.h"
+#include "fmi3FunctionTypes.h"
+#include <stdlib.h>
+
+/*
+Export FMI3 API functions on Windows and under GCC.
+If custom linking is desired then the FMI3_Export must be
+defined before including this file. For instance,
+it may be set to __declspec(dllimport).
+*/
+#if !defined(FMI3_Export)
+  #if !defined(FMI3_FUNCTION_PREFIX)
+    #if defined _WIN32 || defined __CYGWIN__
+     /* Note: both gcc & MSVC on Windows support this syntax. */
+        #define FMI3_Export __declspec(dllexport)
+    #else
+      #if __GNUC__ >= 4
+        #define FMI3_Export __attribute__ ((visibility ("default")))
+      #else
+        #define FMI3_Export
+      #endif
+    #endif
+  #else
+    #define FMI3_Export
+  #endif
+#endif
+
+/*
+Macros to construct the real function name (prepend function name by FMI3_FUNCTION_PREFIX)
+*/
+#if defined(FMI3_FUNCTION_PREFIX)
+  #define fmi3Paste(a,b)     a ## b
+  #define fmi3PasteB(a,b)    fmi3Paste(a,b)
+  #define fmi3FullName(name) fmi3PasteB(FMI3_FUNCTION_PREFIX, name)
+#else
+  #define fmi3FullName(name) name
+#endif
+
+/***************************************************
+Common Functions
+****************************************************/
+#define fmi3GetVersion               fmi3FullName(fmi3GetVersion)
+#define fmi3SetDebugLogging          fmi3FullName(fmi3SetDebugLogging)
+#define fmi3Instantiate              fmi3FullName(fmi3Instantiate)
+#define fmi3FreeInstance             fmi3FullName(fmi3FreeInstance)
+#define fmi3SetupExperiment          fmi3FullName(fmi3SetupExperiment)
+#define fmi3EnterInitializationMode  fmi3FullName(fmi3EnterInitializationMode)
+#define fmi3ExitInitializationMode   fmi3FullName(fmi3ExitInitializationMode)
+#define fmi3Terminate                fmi3FullName(fmi3Terminate)
+#define fmi3Reset                    fmi3FullName(fmi3Reset)
+#define fmi3GetFloat32               fmi3FullName(fmi3GetFloat32)
+#define fmi3GetFloat64               fmi3FullName(fmi3GetFloat64)
+#define fmi3GetInt8                  fmi3FullName(fmi3GetInt8)
+#define fmi3GetUInt8                 fmi3FullName(fmi3GetUInt8)
+#define fmi3GetInt16                 fmi3FullName(fmi3GetInt16)
+#define fmi3GetUInt16                fmi3FullName(fmi3GetUInt16)
+#define fmi3GetInt32                 fmi3FullName(fmi3GetInt32)
+#define fmi3GetUInt32                fmi3FullName(fmi3GetUInt32)
+#define fmi3GetInt64                 fmi3FullName(fmi3GetInt64)
+#define fmi3GetUInt64                fmi3FullName(fmi3GetUInt64)
+#define fmi3GetBoolean               fmi3FullName(fmi3GetBoolean)
+#define fmi3GetString                fmi3FullName(fmi3GetString)
+#define fmi3GetBinary                fmi3FullName(fmi3GetBinary)
+#define fmi3SetFloat32               fmi3FullName(fmi3SetFloat32)
+#define fmi3SetFloat64               fmi3FullName(fmi3SetFloat64)
+#define fmi3SetInt8                  fmi3FullName(fmi3SetInt8)
+#define fmi3SetUInt8                 fmi3FullName(fmi3SetUInt8)
+#define fmi3SetInt16                 fmi3FullName(fmi3SetInt16)
+#define fmi3SetUInt16                fmi3FullName(fmi3SetUInt16)
+#define fmi3SetInt32                 fmi3FullName(fmi3SetInt32)
+#define fmi3SetUInt32                fmi3FullName(fmi3SetUInt32)
+#define fmi3SetInt64                 fmi3FullName(fmi3SetInt64)
+#define fmi3SetUInt64                fmi3FullName(fmi3SetUInt64)
+#define fmi3SetBoolean               fmi3FullName(fmi3SetBoolean)
+#define fmi3SetString                fmi3FullName(fmi3SetString)
+#define fmi3SetBinary                fmi3FullName(fmi3SetBinary)
+#define fmi3GetNumberOfVariableDependencies fmi3FullName(fmi3GetNumberOfVariableDependencies)
+#define fmi3GetVariableDependencies  fmi3FullName(fmi3GetVariableDependencies)
+#define fmi3GetFMUState              fmi3FullName(fmi3GetFMUState)
+#define fmi3SetFMUState              fmi3FullName(fmi3SetFMUState)
+#define fmi3FreeFMUState             fmi3FullName(fmi3FreeFMUState)
+#define fmi3SerializedFMUStateSize   fmi3FullName(fmi3SerializedFMUStateSize)
+#define fmi3SerializeFMUState        fmi3FullName(fmi3SerializeFMUState)
+#define fmi3DeSerializeFMUState      fmi3FullName(fmi3DeSerializeFMUState)
+#define fmi3GetDirectionalDerivative fmi3FullName(fmi3GetDirectionalDerivative)
+
+/***************************************************
+Functions for FMI3 for Model Exchange
+****************************************************/
+
+#define fmi3EnterEventMode                fmi3FullName(fmi3EnterEventMode)
+#define fmi3NewDiscreteStates             fmi3FullName(fmi3NewDiscreteStates)
+#define fmi3EnterContinuousTimeMode       fmi3FullName(fmi3EnterContinuousTimeMode)
+#define fmi3CompletedIntegratorStep       fmi3FullName(fmi3CompletedIntegratorStep)
+#define fmi3SetTime                       fmi3FullName(fmi3SetTime)
+#define fmi3SetContinuousStates           fmi3FullName(fmi3SetContinuousStates)
+#define fmi3GetDerivatives                fmi3FullName(fmi3GetDerivatives)
+#define fmi3GetEventIndicators            fmi3FullName(fmi3GetEventIndicators)
+#define fmi3GetContinuousStates           fmi3FullName(fmi3GetContinuousStates)
+#define fmi3GetNominalsOfContinuousStates fmi3FullName(fmi3GetNominalsOfContinuousStates)
+#define fmi3GetNumberOfEventIndicators    fmi3FullName(fmi3GetNumberOfEventIndicators)
+#define fmi3GetNumberOfContinuousStates   fmi3FullName(fmi3GetNumberOfContinuousStates)
+
+/***************************************************
+Functions for FMI3 for Co-Simulation
+****************************************************/
+
+#define fmi3SetInputDerivatives          fmi3FullName(fmi3SetInputDerivatives)
+#define fmi3GetOutputDerivatives         fmi3FullName(fmi3GetOutputDerivatives)
+#define fmi3DoStep                       fmi3FullName(fmi3DoStep)
+#define fmi3CancelStep                   fmi3FullName(fmi3CancelStep)
+#define fmi3GetDoStepPendingStatus       fmi3FullName(fmi3GetDoStepPendingStatus)
+#define fmi3GetDoStepDiscardedStatus     fmi3FullName(fmi3GetDoStepDiscardedStatus)
+
+/* Version number */
+#define fmi3Version "3.0-wg003.3"
+
+/***************************************************
+Common Functions
+****************************************************/
+
+/* Inquire version numbers and set debug logging */
+FMI3_Export fmi3GetVersionTYPE       fmi3GetVersion;
+FMI3_Export fmi3SetDebugLoggingTYPE  fmi3SetDebugLogging;
+
+/* Creation and destruction of FMU instances */
+FMI3_Export fmi3InstantiateTYPE  fmi3Instantiate;
+FMI3_Export fmi3FreeInstanceTYPE fmi3FreeInstance;
+
+/* Enter and exit initialization mode, terminate and reset */
+FMI3_Export fmi3SetupExperimentTYPE         fmi3SetupExperiment;
+FMI3_Export fmi3EnterInitializationModeTYPE fmi3EnterInitializationMode;
+FMI3_Export fmi3ExitInitializationModeTYPE  fmi3ExitInitializationMode;
+FMI3_Export fmi3TerminateTYPE               fmi3Terminate;
+FMI3_Export fmi3ResetTYPE                   fmi3Reset;
+
+/* Getting and setting variables values */
+FMI3_Export fmi3GetFloat32TYPE fmi3GetFloat32;
+FMI3_Export fmi3GetFloat64TYPE fmi3GetFloat64;
+FMI3_Export fmi3GetInt8TYPE    fmi3GetInt8;
+FMI3_Export fmi3GetUInt8TYPE   fmi3GetUInt8;
+FMI3_Export fmi3GetInt16TYPE   fmi3GetInt16;
+FMI3_Export fmi3GetUInt16TYPE  fmi3GetUInt16;
+FMI3_Export fmi3GetInt32TYPE   fmi3GetInt32;
+FMI3_Export fmi3GetUInt32TYPE  fmi3GetUInt32;
+FMI3_Export fmi3GetInt64TYPE   fmi3GetInt64;
+FMI3_Export fmi3GetUInt64TYPE  fmi3GetUInt64;
+FMI3_Export fmi3GetBooleanTYPE fmi3GetBoolean;
+FMI3_Export fmi3GetStringTYPE  fmi3GetString;
+FMI3_Export fmi3GetBinaryTYPE  fmi3GetBinary;
+FMI3_Export fmi3SetFloat32TYPE fmi3SetFloat32;
+FMI3_Export fmi3SetFloat64TYPE fmi3SetFloat64;
+FMI3_Export fmi3SetInt8TYPE    fmi3SetInt8;
+FMI3_Export fmi3SetUInt8TYPE   fmi3SetUInt8;
+FMI3_Export fmi3SetInt16TYPE   fmi3SetInt16;
+FMI3_Export fmi3SetUInt16TYPE  fmi3SetUInt16;
+FMI3_Export fmi3SetInt32TYPE   fmi3SetInt32;
+FMI3_Export fmi3SetUInt32TYPE  fmi3SetUInt32;
+FMI3_Export fmi3SetInt64TYPE   fmi3SetInt64;
+FMI3_Export fmi3SetUInt64TYPE  fmi3SetUInt64;
+FMI3_Export fmi3SetBooleanTYPE fmi3SetBoolean;
+FMI3_Export fmi3SetStringTYPE  fmi3SetString;
+FMI3_Export fmi3SetBinaryTYPE  fmi3SetBinary;
+FMI3_Export fmi3SetStringTYPE  fmi3SetString;
+FMI3_Export fmi3SetBinaryTYPE  fmi3SetBinary;
+
+/* Getting Variable Dependency Information */
+FMI3_Export fmi3GetNumberOfVariableDependenciesTYPE fmi3GetNumberOfVariableDependencies;
+FMI3_Export fmi3GetVariableDependenciesTYPE         fmi3GetVariableDependencies;
+
+/* Getting and setting the internal FMU state */
+FMI3_Export fmi3GetFMUStateTYPE            fmi3GetFMUState;
+FMI3_Export fmi3SetFMUStateTYPE            fmi3SetFMUState;
+FMI3_Export fmi3FreeFMUStateTYPE           fmi3FreeFMUState;
+FMI3_Export fmi3SerializedFMUStateSizeTYPE fmi3SerializedFMUStateSize;
+FMI3_Export fmi3SerializeFMUStateTYPE      fmi3SerializeFMUState;
+FMI3_Export fmi3DeSerializeFMUStateTYPE    fmi3DeSerializeFMUState;
+
+/* Getting partial derivatives */
+FMI3_Export fmi3GetDirectionalDerivativeTYPE fmi3GetDirectionalDerivative;
+
+/***************************************************
+Functions for FMI3 for Model Exchange
+****************************************************/
+
+/* Enter and exit the different modes */
+FMI3_Export fmi3EnterEventModeTYPE               fmi3EnterEventMode;
+FMI3_Export fmi3NewDiscreteStatesTYPE            fmi3NewDiscreteStates;
+FMI3_Export fmi3EnterContinuousTimeModeTYPE      fmi3EnterContinuousTimeMode;
+FMI3_Export fmi3CompletedIntegratorStepTYPE      fmi3CompletedIntegratorStep;
+
+/* Providing independent variables and re-initialization of caching */
+FMI3_Export fmi3SetTimeTYPE             fmi3SetTime;
+FMI3_Export fmi3SetContinuousStatesTYPE fmi3SetContinuousStates;
+
+/* Evaluation of the model equations */
+FMI3_Export fmi3GetDerivativesTYPE                fmi3GetDerivatives;
+FMI3_Export fmi3GetEventIndicatorsTYPE            fmi3GetEventIndicators;
+FMI3_Export fmi3GetContinuousStatesTYPE           fmi3GetContinuousStates;
+FMI3_Export fmi3GetNominalsOfContinuousStatesTYPE fmi3GetNominalsOfContinuousStates;
+FMI3_Export fmi3GetNumberOfEventIndicatorsTYPE    fmi3GetNumberOfEventIndicators;
+FMI3_Export fmi3GetNumberOfContinuousStatesTYPE   fmi3GetNumberOfContinuousStates;
+
+/***************************************************
+Functions for FMI3 for Co-Simulation
+****************************************************/
+
+/* Simulating the slave */
+FMI3_Export fmi3SetInputDerivativesTYPE  fmi3SetInputDerivatives;
+FMI3_Export fmi3GetOutputDerivativesTYPE fmi3GetOutputDerivatives;
+
+FMI3_Export fmi3DoStepTYPE     fmi3DoStep;
+FMI3_Export fmi3CancelStepTYPE fmi3CancelStep;
+
+/* Inquire slave status */
+FMI3_Export fmi3GetDoStepPendingStatusTYPE   fmi3GetDoStepPendingStatus;
+FMI3_Export fmi3GetDoStepDiscardedStatusTYPE fmi3GetDoStepDiscardedStatus;
+
+#ifdef __cplusplus
+}  /* end of extern "C" { */
+#endif
+
+#endif /* fmi3Functions_h */

--- a/fmpy/c-code/fmi3PlatformTypes.h
+++ b/fmpy/c-code/fmi3PlatformTypes.h
@@ -1,0 +1,87 @@
+#ifndef fmi3PlatformTypes_h
+#define fmi3PlatformTypes_h
+
+/*
+Standard header file to define the argument types of the
+functions of the Functional Mock-up Interface 3.0-wg003.3.
+This header file must be utilized both by the model and
+by the simulation engine.
+
+Copyright (C) 2008-2011 MODELISAR consortium,
+              2012-2019 Modelica Association Project "FMI"
+              All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+*/
+
+/* Include the integer type definitions */
+#include <stdint.h>
+
+
+/* tag::Component[] */
+typedef void*           fmi3Instance;             /* Pointer to FMU instance */
+/* end::Component[] */
+
+/* tag::ComponentEnvironment[] */
+typedef void*           fmi3InstanceEnvironment;  /* Pointer to FMU environment */
+/* end::ComponentEnvironment[] */
+
+/* tag::FMUState[] */
+typedef void*           fmi3FMUState;              /* Pointer to internal FMU state */
+/* end::FMUState[] */
+
+/* tag::ValueReference[] */
+typedef unsigned int    fmi3ValueReference;        /* Handle to the value of a variable */
+/* end::ValueReference[] */
+
+/* tag::VariableTypes[] */
+typedef float           fmi3Float32;  /* Single precision floating point (32-bit) */
+typedef double          fmi3Float64;  /* Double precision floating point (64-bit) */
+typedef   int8_t        fmi3Int8;     /* 8-bit signed integer */
+typedef  uint8_t        fmi3UInt8;    /* 8-bit unsigned integer */
+typedef  int16_t        fmi3Int16;    /* 16-bit signed integer */
+typedef uint16_t        fmi3UInt16;   /* 16-bit unsigned integer */
+typedef  int32_t        fmi3Int32;    /* 32-bit signed integer */
+typedef uint32_t        fmi3UInt32;   /* 32-bit unsigned integer */
+typedef  int64_t        fmi3Int64;    /* 64-bit signed integer */
+typedef uint64_t        fmi3UInt64;   /* 64-bit unsigned integer */
+typedef int             fmi3Boolean;  /* Data type to be used with fmi3True and fmi3False */
+typedef char            fmi3Char;     /* Data type for one character */
+typedef const fmi3Char* fmi3String;   /* Data type for character strings
+                                         ('\0' terminated, UTF8 encoded) */
+typedef char            fmi3Byte;     /* Smallest addressable unit of the machine
+                                         (typically one byte) */
+typedef const fmi3Byte* fmi3Binary;   /* Data type for binary data
+                                         (out-of-band length terminated) */
+
+/* Values for fmi3Boolean */
+#define fmi3True  1
+#define fmi3False 0
+/* end::VariableTypes[] */
+
+#endif /* fmi3PlatformTypes_h */

--- a/fmpy/fmi3.py
+++ b/fmpy/fmi3.py
@@ -9,8 +9,8 @@ from . import architecture, system, sharedLibraryExtension
 
 
 fmi3Component            = c_void_p
-fmi3ComponentEnvironment = c_void_p
-fmi3FMUstate             = c_void_p
+fmi3InstanceEnvironment  = c_void_p
+fmi3FMUState             = c_void_p
 fmi3ValueReference       = c_uint
 fmi3Float32              = c_float
 fmi3Float64              = c_double
@@ -26,7 +26,7 @@ fmi3Boolean              = c_int
 fmi3Char                 = c_char
 fmi3String               = c_char_p
 fmi3Binary               = c_char_p
-fmi3Type                 = c_int
+fmi3InterfaceType        = c_int
 fmi3Byte                 = c_char
 
 fmi3Status = c_int
@@ -38,10 +38,10 @@ fmi3Error   = 3
 fmi3Fatal   = 4
 fmi3Pending = 5
 
-fmi3CallbackLoggerTYPE         = CFUNCTYPE(None, fmi3ComponentEnvironment, fmi3String, fmi3Status, fmi3String, fmi3String)
-fmi3CallbackAllocateMemoryTYPE = CFUNCTYPE(c_void_p, fmi3ComponentEnvironment, c_size_t, c_size_t)
-fmi3CallbackFreeMemoryTYPE     = CFUNCTYPE(None, fmi3ComponentEnvironment, c_void_p)
-fmi3StepFinishedTYPE           = CFUNCTYPE(None, fmi3ComponentEnvironment, fmi3Status)
+fmi3CallbackLogMessageTYPE     = CFUNCTYPE(None, fmi3InstanceEnvironment, fmi3String, fmi3Status, fmi3String, fmi3String)
+fmi3CallbackAllocateMemoryTYPE = CFUNCTYPE(c_void_p, fmi3InstanceEnvironment, c_size_t, c_size_t)
+fmi3CallbackFreeMemoryTYPE     = CFUNCTYPE(None, fmi3InstanceEnvironment, c_void_p)
+fmi3CallbackStepFinishedTYPE   = CFUNCTYPE(None, fmi3InstanceEnvironment, fmi3Status)
 
 fmi3ModelExchange = 0
 fmi3CoSimulation  = 1
@@ -53,20 +53,20 @@ fmi3False = 0
 _mem_addr = set()
 
 
-def printLogMessage(componentEnvironment, instanceName, status, category, message):
+def printLogMessage(instanceEnvironment, instanceName, status, category, message):
     """ Print the FMU's log messages to the command line """
 
     label = ['OK', 'WARNING', 'DISCARD', 'ERROR', 'FATAL', 'PENDING'][status]
     print("[%s] %s" % (label, message))
 
 
-def allocateMemory(componentEnvironment, nobj, size):
+def allocateMemory(instanceEnvironment, nobj, size):
     mem = calloc(nobj, size)
     _mem_addr.add(mem)
     return mem
 
 
-def freeMemory(componentEnvironment, obj):
+def freeMemory(instanceEnvironment, obj):
     if obj in _mem_addr:
         free(obj)
         _mem_addr.remove(obj)
@@ -74,17 +74,17 @@ def freeMemory(componentEnvironment, obj):
         print("freeMemory() was called for a pointer (%s) that was not allocated" % obj)
 
 
-def stepFinished(componentEnvironment, status):
+def stepFinished(instanceEnvironment, status):
     pass
 
 
 class fmi3CallbackFunctions(Structure):
 
-    _fields_ = [('logger',               fmi3CallbackLoggerTYPE),
-                ('allocateMemory',       fmi3CallbackAllocateMemoryTYPE),
-                ('freeMemory',           fmi3CallbackFreeMemoryTYPE),
-                ('stepFinished',         fmi3StepFinishedTYPE),
-                ('componentEnvironment', fmi3ComponentEnvironment)]
+    _fields_ = [('logMessage',          fmi3CallbackLogMessageTYPE),
+                ('allocateMemory',      fmi3CallbackAllocateMemoryTYPE),
+                ('freeMemory',          fmi3CallbackFreeMemoryTYPE),
+                ('stepFinished',        fmi3CallbackStepFinishedTYPE),
+                ('instanceEnvironment', fmi3InstanceEnvironment)]
 
 
 class fmi3EventInfo(Structure):
@@ -120,7 +120,7 @@ class _FMU3(_FMU):
         # Creation and destruction of FMU instances and setting debug status
         self._fmi3Function('fmi3Instantiate',
                            ['instanceName', 'fmuType', 'guid', 'resourceLocation', 'callbacks', 'visible', 'loggingOn'],
-                           [fmi3String, fmi3Type, fmi3String, fmi3String, POINTER(fmi3CallbackFunctions), fmi3Boolean, fmi3Boolean],
+                           [fmi3String, fmi3InterfaceType, fmi3String, fmi3String, POINTER(fmi3CallbackFunctions), fmi3Boolean, fmi3Boolean],
                            fmi3Component)
 
         self._fmi3Function('fmi3FreeInstance', ['component'], [fmi3Component], None)
@@ -173,26 +173,26 @@ class _FMU3(_FMU):
                            [fmi3Component, POINTER(fmi3ValueReference), c_size_t, POINTER(c_size_t), POINTER(fmi3Binary), c_size_t])
 
         # Getting and setting the internal FMU state
-        self._fmi3Function('fmi3GetFMUstate', ['component', 'FMUstate'],
-                           [fmi3Component, POINTER(fmi3FMUstate)])
+        self._fmi3Function('fmi3GetFMUState', ['component', 'FMUState'],
+                           [fmi3Component, POINTER(fmi3FMUState)])
 
-        self._fmi3Function('fmi3SetFMUstate', ['component', 'FMUstate'],
-                           [fmi3Component, fmi3FMUstate])
+        self._fmi3Function('fmi3SetFMUState', ['component', 'FMUState'],
+                           [fmi3Component, fmi3FMUState])
 
-        self._fmi3Function('fmi3FreeFMUstate', ['component', 'FMUstate'],
-                           [fmi3Component, POINTER(fmi3FMUstate)])
+        self._fmi3Function('fmi3FreeFMUState', ['component', 'FMUState'],
+                           [fmi3Component, POINTER(fmi3FMUState)])
 
-        self._fmi3Function('fmi3SerializedFMUstateSize',
-                           ['component', 'FMUstate', 'size'],
-                           [fmi3Component, fmi3FMUstate, POINTER(c_size_t)])
+        self._fmi3Function('fmi3SerializedFMUStateSize',
+                           ['component', 'FMUState', 'size'],
+                           [fmi3Component, fmi3FMUState, POINTER(c_size_t)])
 
-        self._fmi3Function('fmi3SerializeFMUstate',
-                           ['component', 'FMUstate', 'serializedState', 'size'],
-                           [fmi3Component, fmi3FMUstate, POINTER(fmi3Byte), c_size_t])
+        self._fmi3Function('fmi3SerializeFMUState',
+                           ['component', 'FMUState', 'serializedState', 'size'],
+                           [fmi3Component, fmi3FMUState, POINTER(fmi3Byte), c_size_t])
 
-        self._fmi3Function('fmi3DeSerializeFMUstate',
-                           ['component', 'FMUstate', 'serializedState', 'size'],
-                           [fmi3Component, POINTER(fmi3Byte), c_size_t, POINTER(fmi3FMUstate)])
+        self._fmi3Function('fmi3DeSerializeFMUState',
+                           ['component', 'FMUState', 'serializedState', 'size'],
+                           [fmi3Component, POINTER(fmi3Byte), c_size_t, POINTER(fmi3FMUState)])
 
         # Getting partial derivatives
         self._fmi3Function('fmi3GetDirectionalDerivative',
@@ -258,7 +258,7 @@ class _FMU3(_FMU):
 
         if callbacks is None:
             callbacks = fmi3CallbackFunctions()
-            callbacks.logger = fmi3CallbackLoggerTYPE(printLogMessage)
+            callbacks.logger = fmi3CallbackLogMessageTYPE(printLogMessage)
             callbacks.allocateMemory = fmi3CallbackAllocateMemoryTYPE(allocateMemory)
             callbacks.freeMemory = fmi3CallbackFreeMemoryTYPE(freeMemory)
 
@@ -386,18 +386,18 @@ class _FMU3(_FMU):
 
     # Getting and setting the internal FMU state
 
-    def getFMUstate(self):
-        state = fmi3FMUstate()
-        self.fmi3GetFMUstate(self.component, byref(state))
+    def getFMUState(self):
+        state = fmi3FMUState()
+        self.fmi3GetFMUState(self.component, byref(state))
         return state
 
-    def setFMUstate(self, state):
-        self.fmi3SetFMUstate(self.component, state)
+    def setFMUState(self, state):
+        self.fmi3SetFMUState(self.component, state)
 
-    def freeFMUstate(self, state):
-        self.fmi3FreeFMUstate(self.component, byref(state))
+    def freeFMUState(self, state):
+        self.fmi3FreeFMUState(self.component, byref(state))
 
-    def serializeFMUstate(self, state):
+    def serializeFMUState(self, state):
         """ Serialize an FMU state
 
         Parameters:
@@ -408,12 +408,12 @@ class _FMU3(_FMU):
         """
 
         size = c_size_t()
-        self.fmi3SerializedFMUstateSize(self.component, state, byref(size))
+        self.fmi3SerializedFMUStateSize(self.component, state, byref(size))
         serializedState = create_string_buffer(size.value)
-        self.fmi3SerializeFMUstate(self.component, state, serializedState, size)
+        self.fmi3SerializeFMUState(self.component, state, serializedState, size)
         return serializedState.raw
 
-    def deSerializeFMUstate(self, serializedState, state):
+    def deSerializeFMUState(self, serializedState, state):
         """ De-serialize an FMU state
 
         Parameters:
@@ -422,7 +422,7 @@ class _FMU3(_FMU):
         """
 
         buffer = create_string_buffer(serializedState)
-        self.fmi3DeSerializeFMUstate(self.component, buffer, len(buffer), byref(state))
+        self.fmi3DeSerializeFMUState(self.component, buffer, len(buffer), byref(state))
 
     # Getting partial derivatives
 

--- a/fmpy/gui/simulation.py
+++ b/fmpy/gui/simulation.py
@@ -8,12 +8,13 @@ class SimulationThread(QThread):
     progressChanged = pyqtSignal(int)
     messageChanged = pyqtSignal(str, str)
 
-    def __init__(self, filename, fmiType, stopTime, solver, stepSize, relativeTolerance, outputInterval, startValues, applyDefaultStartValues, input, output, debugLogging, fmiLogging, parent=None):
+    def __init__(self, filename, fmiType, startTime, stopTime, solver, stepSize, relativeTolerance, outputInterval, startValues, applyDefaultStartValues, input, output, debugLogging, fmiLogging, parent=None):
 
         super(SimulationThread, self).__init__(parent)
 
         self.filename = filename
         self.fmiType = fmiType
+        self.startTime = startTime
         self.stopTime = stopTime
         self.solver = solver
         self.stepSize = stepSize
@@ -66,10 +67,11 @@ class SimulationThread(QThread):
 
     def run(self):
 
-        startTime = QDateTime.currentMSecsSinceEpoch()
+        #startTime = QDateTime.currentMSecsSinceEpoch()
 
         try:
             self.result = simulate_fmu(self.filename,
+									   start_time=self.startTime,
                                        stop_time=self.stopTime,
                                        solver=self.solver,
                                        step_size=self.stepSize,
@@ -86,7 +88,7 @@ class SimulationThread(QThread):
                                        step_finished=self.stepFinished)
         except Exception as e:
             self.messageChanged.emit('error', str(e))
-
+        startTime = QDateTime.currentMSecsSinceEpoch()
         stopTime = QDateTime.currentMSecsSinceEpoch()
         totalTime = ((stopTime - startTime) / 1000.)
 

--- a/fmpy/model_description.py
+++ b/fmpy/model_description.py
@@ -415,7 +415,11 @@ def read_model_description(filename, validate=True):
         type_definitions[simple_type.name] = simple_type
 
     # FMI 3
-    for t in root.findall('TypeDefinitions'):
+    for t in root.findall('TypeDefinitions/*'):
+
+        if t.tag not in {'Float32', 'Float64', 'Int8', 'UInt8', 'Int16', 'UInt16', 'Int32', 'UInt32', 'Int64', 'UInt64',
+                         'Boolean', 'String', 'Binary', 'Enumeration'}:
+            continue
 
         simple_type = SimpleType(type=t.tag, **t.attrib)
 

--- a/fmpy/model_description.py
+++ b/fmpy/model_description.py
@@ -393,6 +393,7 @@ def read_model_description(filename, validate=True):
     # type definitions
     type_definitions = {None: None}
 
+    # FMI 1 and 2
     for t in root.findall('TypeDefinitions/' + ('Type' if fmiVersion == "1.0" else 'SimpleType')):
 
         first = t[0]  # first element
@@ -408,6 +409,19 @@ def read_model_description(filename, validate=True):
             it = Item(**item.attrib)
             if fmiVersion == '1.0':
                 it.value = i + 1
+            simple_type.items.append(it)
+
+        modelDescription.typeDefinitions.append(simple_type)
+        type_definitions[simple_type.name] = simple_type
+
+    # FMI 3
+    for t in root.findall('TypeDefinitions'):
+
+        simple_type = SimpleType(type=t.tag, **t.attrib)
+
+        # add enumeration items
+        for item in t.findall('Item'):
+            it = Item(**item.attrib)
             simple_type.items.append(it)
 
         modelDescription.typeDefinitions.append(simple_type)

--- a/fmpy/model_description.py
+++ b/fmpy/model_description.py
@@ -301,8 +301,10 @@ def read_model_description(filename, validate=True):
 
     if fmiVersion == '1.0':
         modelDescription.numberOfContinuousStates = int(root.get('numberOfContinuousStates'))
-    else:
+    elif fmiVersion == '2.0':
         modelDescription.numberOfContinuousStates = len(root.findall('ModelStructure/Derivatives/Unknown'))
+    else:
+        modelDescription.numberOfContinuousStates = len(root.findall('ModelStructure/Derivative'))
 
     # default experiment
     for d in root.findall('DefaultExperiment'):

--- a/fmpy/model_description.py
+++ b/fmpy/model_description.py
@@ -394,7 +394,7 @@ def read_model_description(filename, validate=True):
     type_definitions = {None: None}
 
     # FMI 1 and 2
-    for t in root.findall('TypeDefinitions/' + ('Type' if fmiVersion == "1.0" else 'SimpleType')):
+    for t in root.findall('TypeDefinitions/' + ('Type' if fmiVersion == '1.0' else 'SimpleType')):
 
         first = t[0]  # first element
 

--- a/fmpy/model_description.py
+++ b/fmpy/model_description.py
@@ -51,7 +51,7 @@ class CoSimulation(object):
         self.canGetAndSetFMUstate = False
         self.canSerializeFMUstate = False
         self.providesDirectionalDerivative = False
-        self.sourceFiles = []
+        self.buildConfigurations = []
 
 
 class ModelExchange(object):
@@ -65,7 +65,40 @@ class ModelExchange(object):
         self.canGetAndSetFMUstate = False
         self.canSerializeFMUstate = False
         self.providesDirectionalDerivative = False
+        self.buildConfigurations = []
+
+
+class BuildConfiguration(object):
+
+    def __init__(self):
+        self.sourceFileSets = []
+
+    def __repr__(self):
+        return 'BuildConfiguration %s' % self.sourceFileSets
+
+
+class PreProcessorDefinition(object):
+
+    def __init__(self):
+        self.name = None
+        self.value = None
+        self.optional = False
+        self.description = None
+
+    def __repr__(self):
+        return '%s=%s' % (self.name, self.value)
+
+
+class SourceFileSet(object):
+
+    def __init__(self):
+        self.language = None
+        self.preprocessorDefinitions = []
         self.sourceFiles = []
+        self.includeDirectories = []
+
+    def __repr__(self):
+        return '%s %s' % (self.language, self.sourceFiles)
 
 
 class ScalarVariable(object):
@@ -241,6 +274,53 @@ def _copy_attributes(element, object, attributes):
         setattr(object, attribute, value)
 
 
+def _get_build_configurations(fmi_version, implementation):
+
+    build_configurations = []
+
+    if fmi_version == '2.0':
+
+        source_files = [file.get('name') for file in implementation.findall('SourceFiles/File')]
+
+        if len(source_files) > 0:
+            build_configuration = BuildConfiguration()
+            build_configurations.append(build_configuration)
+            source_file_set = SourceFileSet()
+            build_configuration.sourceFileSets.append(source_file_set)
+            source_file_set.sourceFiles = source_files
+
+        return build_configurations
+
+    for bc in implementation.findall('BuildConfiguration'):
+
+        buildConfiguration = BuildConfiguration()
+
+        build_configurations.append(buildConfiguration)
+
+        for sf in bc.findall('SourceFileSet'):
+
+            sourceFileSet = SourceFileSet()
+            sourceFileSet.language = sf.get('language')
+
+            for pd in sf.findall('PreprocessorDefinition'):
+                definition = PreProcessorDefinition()
+                definition.name = pd.get('name')
+                definition.value = pd.get('value')
+                definition.optional = pd.get('optional') == 'true'
+                definition.description = pd.get('description')
+                sourceFileSet.preprocessorDefinitions.append(definition)
+
+            for f in sf.findall('SourceFile'):
+                sourceFileSet.sourceFiles.append(f.get('name'))
+
+            for d in sf.findall('IncludeDirectory'):
+                sourceFileSet.includeDirectories.append(d.get('name'))
+
+            buildConfiguration.sourceFileSets.append(sourceFileSet)
+
+    return build_configurations
+
+
 def read_model_description(filename, validate=True):
     """ Read the model description from an FMU without extracting it
 
@@ -340,8 +420,7 @@ def read_model_description(filename, validate=True):
                               'canGetAndSetFMUstate',
                               'canSerializeFMUstate',
                               'providesDirectionalDerivative'])
-            for file in me.findall('SourceFiles/File'):
-                modelDescription.modelExchange.sourceFiles.append(file.get('name'))
+            modelDescription.modelExchange.buildConfigurations = _get_build_configurations(fmiVersion, me)
 
         for cs in root.findall('CoSimulation'):
             modelDescription.coSimulation = CoSimulation()
@@ -357,8 +436,7 @@ def read_model_description(filename, validate=True):
                               'canGetAndSetFMUstate',
                               'canSerializeFMUstate',
                               'providesDirectionalDerivative'])
-            for file in cs.findall('SourceFiles/File'):
-                modelDescription.coSimulation.sourceFiles.append(file.get('name'))
+            modelDescription.coSimulation.buildConfigurations = _get_build_configurations(fmiVersion, cs)
 
     # unit definitions
     if fmiVersion == "1.0":

--- a/fmpy/schema/fmi3/fmi3FMUType.xsd
+++ b/fmpy/schema/fmi3/fmi3FMUType.xsd
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:annotation>
+		<xs:documentation>
+Copyright(c) 2008-2011 MODELISAR consortium,
+             2012-2019 Modelica Association Project "FMI".
+             All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+		</xs:documentation>
+	</xs:annotation>
+	<xs:include schemaLocation="fmi3Annotation.xsd"/>
+	<xs:complexType name="fmi3FMUType">
+		<xs:sequence minOccurs="0">
+			<xs:element name="BuildConfiguration" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SourceFileSet" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="SourceFile" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="PreprocessorDefinition" minOccurs="0" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Option" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:attribute name="value" type="xs:normalizedString"/>
+														<xs:attribute name="description" type="xs:string"/>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+											<xs:attribute name="optional" type="xs:boolean" default="false"/>
+											<xs:attribute name="value" type="xs:normalizedString"/>
+											<xs:attribute name="description" type="xs:string"/>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="IncludeDirectory" minOccurs="0" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="language" type="xs:normalizedString"/>
+								<xs:attribute name="compiler" type="xs:normalizedString"/>
+								<xs:attribute name="compilerOptions" type="xs:string"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Library" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+								<xs:attribute name="version" type="xs:normalizedString"/>
+								<xs:attribute name="external" type="xs:boolean" default="false"/>
+								<xs:attribute name="description" type="xs:string"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="platform" type="xs:normalizedString"/>
+					<xs:attribute name="description" type="xs:string"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="VendorAnnotations" type="fmi3Annotation" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
+		<xs:attribute name="needsExecutionTool" type="xs:boolean" default="false"/>
+		<xs:attribute name="canBeInstantiatedOnlyOncePerProcess" type="xs:boolean" default="false"/>
+		<xs:attribute name="canNotUseMemoryManagementFunctions" type="xs:boolean" default="false"/>
+		<xs:attribute name="canGetAndSetFMUState" type="xs:boolean" default="false"/>
+		<xs:attribute name="canSerializeFMUState" type="xs:boolean" default="false"/>
+		<xs:attribute name="providesDirectionalDerivative" type="xs:boolean" default="false"/>
+		<xs:attribute name="providesPerElementDependencies" type="xs:boolean" default="false"/>
+	</xs:complexType>
+</xs:schema>

--- a/fmpy/schema/fmi3/fmi3ModelDescription.xsd
+++ b/fmpy/schema/fmi3/fmi3ModelDescription.xsd
@@ -4,6 +4,7 @@
 	<xs:include schemaLocation="fmi3Unit.xsd"/>
 	<xs:include schemaLocation="fmi3Variable.xsd"/>
 	<xs:include schemaLocation="fmi3Type.xsd"/>
+	<xs:include schemaLocation="fmi3FMUType.xsd"/>
 	<xs:annotation>
 		<xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
@@ -44,59 +45,23 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:sequence maxOccurs="2">
 					<xs:element name="ModelExchange" minOccurs="0">
 						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="SourceFiles" minOccurs="0">
-									<xs:complexType>
-										<xs:sequence maxOccurs="unbounded">
-											<xs:element name="File">
-												<xs:complexType>
-													<xs:attribute name="name" type="xs:normalizedString" use="required">
-													</xs:attribute>
-												</xs:complexType>
-											</xs:element>
-										</xs:sequence>
-									</xs:complexType>
-								</xs:element>
-							</xs:sequence>
-							<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
-							<xs:attribute name="needsExecutionTool" type="xs:boolean" default="false"/>
-							<xs:attribute name="completedIntegratorStepNotNeeded" type="xs:boolean" default="false"/>
-							<xs:attribute name="canBeInstantiatedOnlyOncePerProcess" type="xs:boolean" default="false"/>
-							<xs:attribute name="canNotUseMemoryManagementFunctions" type="xs:boolean" default="false"/>
-							<xs:attribute name="canGetAndSetFMUstate" type="xs:boolean" default="false"/>
-							<xs:attribute name="canSerializeFMUstate" type="xs:boolean" default="false"/>
-							<xs:attribute name="providesDirectionalDerivative" type="xs:boolean" default="false"/>
-							<xs:attribute name="providesPerElementDependencies" type="xs:boolean" default="false"/>
+							<xs:complexContent>
+								<xs:extension base="fmi3FMUType">
+									<xs:attribute name="completedIntegratorStepNotNeeded" type="xs:boolean" default="false"/>
+								</xs:extension>
+							</xs:complexContent>
 						</xs:complexType>
 					</xs:element>
 					<xs:element name="CoSimulation" minOccurs="0">
 						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="SourceFiles" minOccurs="0">
-									<xs:complexType>
-										<xs:sequence maxOccurs="unbounded">
-											<xs:element name="File">
-												<xs:complexType>
-													<xs:attribute name="name" type="xs:normalizedString" use="required">
-													</xs:attribute>
-												</xs:complexType>
-											</xs:element>
-										</xs:sequence>
-									</xs:complexType>
-								</xs:element>
-							</xs:sequence>
-							<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
-							<xs:attribute name="needsExecutionTool" type="xs:boolean" default="false"/>
-							<xs:attribute name="canHandleVariableCommunicationStepSize" type="xs:boolean" default="false"/>
-							<xs:attribute name="canInterpolateInputs" type="xs:boolean" default="false"/>
-							<xs:attribute name="maxOutputDerivativeOrder" type="xs:unsignedInt" default="0"/>
-							<xs:attribute name="canRunAsynchronuously" type="xs:boolean" default="false"/>
-							<xs:attribute name="canBeInstantiatedOnlyOncePerProcess" type="xs:boolean" default="false"/>
-							<xs:attribute name="canNotUseMemoryManagementFunctions" type="xs:boolean" default="false"/>
-							<xs:attribute name="canGetAndSetFMUstate" type="xs:boolean" default="false"/>
-							<xs:attribute name="canSerializeFMUstate" type="xs:boolean" default="false"/>
-							<xs:attribute name="providesDirectionalDerivative" type="xs:boolean" default="false"/>
-							<xs:attribute name="providesPerElementDependencies" type="xs:boolean" default="false"/>
+							<xs:complexContent>
+								<xs:extension base="fmi3FMUType">
+									<xs:attribute name="canHandleVariableCommunicationStepSize" type="xs:boolean" default="false"/>
+									<xs:attribute name="canInterpolateInputs" type="xs:boolean" default="false"/>
+									<xs:attribute name="maxOutputDerivativeOrder" type="xs:unsignedInt" default="0"/>
+									<xs:attribute name="canRunAsynchronuously" type="xs:boolean" default="false"/>
+								</xs:extension>
+							</xs:complexContent>
 						</xs:complexType>
 					</xs:element>
 				</xs:sequence>

--- a/fmpy/schema/fmi3/fmi3ModelDescription.xsd
+++ b/fmpy/schema/fmi3/fmi3ModelDescription.xsd
@@ -109,9 +109,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				</xs:element>
 				<xs:element name="TypeDefinitions" minOccurs="0">
 					<xs:complexType>
-						<xs:sequence maxOccurs="unbounded">
-							<xs:element name="SimpleType" type="fmi3SimpleType"/>
-						</xs:sequence>
+						<xs:group ref="fmi3TypeDefintion" maxOccurs="unbounded"/>
 					</xs:complexType>
 				</xs:element>
 				<xs:element name="LogCategories" minOccurs="0">
@@ -144,41 +142,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<xs:element name="ModelStructure">
 					<xs:complexType>
 						<xs:sequence>
-							<xs:element name="Outputs" type="fmi3VariableDependency" minOccurs="0">
-							</xs:element>
-							<xs:element name="Derivatives" type="fmi3VariableDependency" minOccurs="0">
-							</xs:element>
-							<xs:element name="InitialUnknowns" minOccurs="0">
-								<xs:complexType>
-									<xs:sequence maxOccurs="unbounded">
-										<xs:element name="Unknown">
-											<xs:complexType>
-												<xs:attribute name="valueReference" type="xs:unsignedInt" use="required"/>
-												<xs:attribute name="dependencies">
-													<xs:simpleType>
-														<xs:list itemType="xs:unsignedInt"/>
-													</xs:simpleType>
-												</xs:attribute>
-												<xs:attribute name="dependenciesKind">
-													<xs:simpleType>
-														<xs:list>
-															<xs:simpleType>
-																<xs:restriction base="xs:normalizedString">
-																	<xs:enumeration value="dependent"/>
-																	<xs:enumeration value="constant"/>
-																	<xs:enumeration value="fixed"/>
-																	<xs:enumeration value="tunable"/>
-																	<xs:enumeration value="discrete"/>
-																</xs:restriction>
-															</xs:simpleType>
-														</xs:list>
-													</xs:simpleType>
-												</xs:attribute>
-											</xs:complexType>
-										</xs:element>
-									</xs:sequence>
-								</xs:complexType>
-							</xs:element>
+							<xs:element name="Output" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="Derivative" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
+							<xs:element name="InitialUnknown" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
 							<xs:element name="NumberOfEventIndicators" minOccurs="0">
 								<xs:complexType>
 									<xs:attribute name="dependencies" use="required">

--- a/fmpy/schema/fmi3/fmi3Type.xsd
+++ b/fmpy/schema/fmi3/fmi3Type.xsd
@@ -35,84 +35,134 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
 		</xs:documentation>
 	</xs:annotation>
-	<xs:complexType name="fmi3SimpleType">
-		<xs:sequence>
-			<xs:choice>
-				<xs:element name="Float64">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3Float64Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Float32">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3Float32Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Int8">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3Int8Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="UInt8">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3UInt8Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Int16">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3Int16Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="UInt16">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3UInt16Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Int32">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3Int32Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="UInt32">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3UInt32Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Int64">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3Int64Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="UInt64">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3UInt64Attributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Boolean"/>
-				<xs:element name="String"/>
-				<xs:element name="Binary">
-					<xs:complexType>
-						<xs:attribute name="mimeType" type="xs:normalizedString" use="optional" default="application/octet-stream"/>
-						<xs:attribute name="maxSize" type="xs:nonNegativeInteger" use="optional"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Enumeration">
-					<xs:complexType>
-						<xs:sequence maxOccurs="unbounded">
-							<xs:element name="Item">
-								<xs:complexType>
-									<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-									<xs:attribute name="value" type="xs:int" use="required"/>
-									<xs:attribute name="description" type="xs:string"/>
-								</xs:complexType>
-							</xs:element>
-						</xs:sequence>
-						<xs:attribute name="quantity" type="xs:normalizedString"/>
-					</xs:complexType>
-				</xs:element>
-			</xs:choice>
-		</xs:sequence>
+
+	<xs:complexType name="fmi3TypeDefintionBase" abstract="true">
 		<xs:attribute name="name" type="xs:normalizedString" use="required"/>
 		<xs:attribute name="description" type="xs:string"/>
 	</xs:complexType>
+
+	<xs:group name="fmi3TypeDefintion">
+		<xs:choice>
+			<xs:element name="Float32">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3Float32Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Float64">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3Float64Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Int8">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3Int8Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UInt8">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3UInt8Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Int16">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3Int16Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UInt16">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3UInt16Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Int32">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3Int32Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UInt32">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3UInt32Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Int64">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3Int64Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="UInt64">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attributeGroup ref="fmi3UInt64Attributes"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Boolean" type="fmi3TypeDefintionBase"/>
+			<xs:element name="String" type="fmi3TypeDefintionBase"/>
+			<xs:element name="Binary">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:attribute name="mimeType" type="xs:normalizedString" use="optional" default="application/octet-stream"/>
+							<xs:attribute name="maxSize" type="xs:nonNegativeInteger" use="optional"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Enumeration">
+				<xs:complexType>
+					<xs:complexContent>
+						<xs:extension base="fmi3TypeDefintionBase">
+							<xs:sequence maxOccurs="unbounded">
+								<xs:element name="Item">
+									<xs:complexType>
+										<xs:attribute name="name" type="xs:normalizedString" use="required"/>
+										<xs:attribute name="value" type="xs:int" use="required"/>
+										<xs:attribute name="description" type="xs:string"/>
+									</xs:complexType>
+								</xs:element>
+							</xs:sequence>
+							<xs:attribute name="quantity" type="xs:normalizedString"/>
+						</xs:extension>
+					</xs:complexContent>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
 </xs:schema>

--- a/fmpy/schema/fmi3/fmi3Variable.xsd
+++ b/fmpy/schema/fmi3/fmi3Variable.xsd
@@ -271,16 +271,10 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	</xs:complexType>
 	<xs:complexType name="fmi3VariableBase" abstract="true">
 		<xs:sequence>
-			<xs:element name="Dimensions" minOccurs="0">
+			<xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
 				<xs:complexType>
-					<xs:sequence maxOccurs="unbounded">
-						<xs:element name="Dimension">
-							<xs:complexType>
-								<xs:attribute name="start" type="xs:unsignedInt"/>
-								<xs:attribute name="valueReference" type="xs:unsignedInt"/>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
+					<xs:attribute name="start" type="xs:unsignedInt"/>
+					<xs:attribute name="valueReference" type="xs:unsignedInt"/>
 				</xs:complexType>
 			</xs:element>
 			<xs:element name="Annotations" type="fmi3Annotation" minOccurs="0"/>

--- a/fmpy/schema/fmi3/fmi3VariableDependency.xsd
+++ b/fmpy/schema/fmi3/fmi3VariableDependency.xsd
@@ -34,33 +34,27 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
 		</xs:documentation>
 	</xs:annotation>
-	<xs:complexType name="fmi3VariableDependency">
-		<xs:sequence maxOccurs="unbounded">
-			<xs:element name="Unknown">
-				<xs:complexType>
-					<xs:attribute name="valueReference" type="xs:unsignedInt" use="required"/>
-					<xs:attribute name="dependencies">
-						<xs:simpleType>
-							<xs:list itemType="xs:unsignedInt"/>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="dependenciesKind">
-						<xs:simpleType>
-							<xs:list>
-								<xs:simpleType>
-									<xs:restriction base="xs:normalizedString">
-										<xs:enumeration value="dependent"/>
-										<xs:enumeration value="constant"/>
-										<xs:enumeration value="fixed"/>
-										<xs:enumeration value="tunable"/>
-										<xs:enumeration value="discrete"/>
-									</xs:restriction>
-								</xs:simpleType>
-							</xs:list>
-						</xs:simpleType>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
+	<xs:complexType name="fmi3Unknown">
+		<xs:attribute name="valueReference" type="xs:unsignedInt" use="required"/>
+		<xs:attribute name="dependencies">
+			<xs:simpleType>
+				<xs:list itemType="xs:unsignedInt"/>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="dependenciesKind">
+			<xs:simpleType>
+				<xs:list>
+					<xs:simpleType>
+						<xs:restriction base="xs:normalizedString">
+							<xs:enumeration value="dependent"/>
+							<xs:enumeration value="constant"/>
+							<xs:enumeration value="fixed"/>
+							<xs:enumeration value="tunable"/>
+							<xs:enumeration value="discrete"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:list>
+			</xs:simpleType>
+		</xs:attribute>
 	</xs:complexType>
 </xs:schema>

--- a/fmpy/simulation.py
+++ b/fmpy/simulation.py
@@ -547,7 +547,7 @@ def simulate_fmu(filename,
         callbacks.freeMemory = fmi2CallbackFreeMemoryTYPE(freeMemory)
     else:
         callbacks = fmi3.fmi3CallbackFunctions()
-        callbacks.logger = fmi3.fmi3CallbackLoggerTYPE(logger)
+        callbacks.logger = fmi3.fmi3CallbackLogMessageTYPE(logger)
         callbacks.allocateMemory = fmi3.fmi3CallbackAllocateMemoryTYPE(fmi3.allocateMemory)
         callbacks.freeMemory = fmi3.fmi3CallbackFreeMemoryTYPE(fmi3.freeMemory)
 

--- a/fmpy/simulation.py
+++ b/fmpy/simulation.py
@@ -536,20 +536,20 @@ def simulate_fmu(filename,
 
     if model_description.fmiVersion == '1.0':
         callbacks = fmi1CallbackFunctions()
-        callbacks.logger = fmi1CallbackLoggerTYPE(logger)
+        callbacks.logger         = fmi1CallbackLoggerTYPE(logger)
         callbacks.allocateMemory = fmi1CallbackAllocateMemoryTYPE(allocateMemory)
-        callbacks.freeMemory = fmi1CallbackFreeMemoryTYPE(freeMemory)
+        callbacks.freeMemory     = fmi1CallbackFreeMemoryTYPE(freeMemory)
         callbacks.stepFinished = None
     elif model_description.fmiVersion == '2.0':
         callbacks = fmi2CallbackFunctions()
-        callbacks.logger = fmi2CallbackLoggerTYPE(logger)
+        callbacks.logger         = fmi2CallbackLoggerTYPE(logger)
         callbacks.allocateMemory = fmi2CallbackAllocateMemoryTYPE(allocateMemory)
-        callbacks.freeMemory = fmi2CallbackFreeMemoryTYPE(freeMemory)
+        callbacks.freeMemory     = fmi2CallbackFreeMemoryTYPE(freeMemory)
     else:
         callbacks = fmi3.fmi3CallbackFunctions()
-        callbacks.logger = fmi3.fmi3CallbackLogMessageTYPE(logger)
+        callbacks.logMessage     = fmi3.fmi3CallbackLogMessageTYPE(logger)
         callbacks.allocateMemory = fmi3.fmi3CallbackAllocateMemoryTYPE(fmi3.allocateMemory)
-        callbacks.freeMemory = fmi3.fmi3CallbackFreeMemoryTYPE(fmi3.freeMemory)
+        callbacks.freeMemory     = fmi3.fmi3CallbackFreeMemoryTYPE(fmi3.freeMemory)
 
     # simulate_fmu the FMU
     if fmi_type == 'ModelExchange' and model_description.modelExchange is not None:


### PR DESCRIPTION
For some FMUs we needed start_time different from zero, like when simulation time comes from calender times. This adds a text field to type in a start_time value and changes the corresponding python code. 
Regards, 
Jorge Bernal