### PR TITLE
Use pathlib2 instead of pathlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ package_data = {
     'fmpy.ssp': ['schema/*.xsd'],
 }
 
-install_requires = ['lark-parser', 'lxml', 'numpy', 'pathlib', 'pywin32;platform_system=="Windows"']
+install_requires = ['lark-parser', 'lxml', 'numpy', 'pathlib2', 'pywin32;platform_system=="Windows"']
 
 extras_require = {
     'examples': ['dask[bag]', 'requests'],


### PR DESCRIPTION
The version of `pathlib` on pypi is years out of date and causes some dependency issues. `pathlib2` is more recent if python 2 should still be supported. The explicit dependency can be removed entirely if only python >3.3 is supported as `pathlib` becomes part of the standard library.