### PR TITLE
Fix bug in custom_input.py example

### DIFF
--- a/fmpy/examples/custom_input.py
+++ b/fmpy/examples/custom_input.py
@@ -70,11 +70,11 @@ def simulate_custom_input(show_plot=True):
             print("Threshold reached at t = %g s" % time)
             break
 
-        # append the results
-        rows.append((time, inputs, outputs4))
-
         # advance the time
         time += step_size
+
+        # append the results
+        rows.append((time, inputs, outputs4))
 
     fmu.terminate()
     fmu.freeInstance()


### PR DESCRIPTION
Advance the time before appending to the result list (`rows`). This is necessary, because the values which are appended to the list are retrieved after the call to `doStep`, which advances the time by the step size. So the results should be stored with the time also advanced by one time step.

I understand that you are not accepting PRs at the moment but i just wanted to leave it here just in case you will at some point in the future. I will also create an issue and link them.