### PR TITLE
FMU Container: Make generation datetime configurable

### DIFF
--- a/fmpy/fmucontainer/__init__.py
+++ b/fmpy/fmucontainer/__init__.py
@@ -63,7 +63,7 @@ FMI_TYPES = {
 }
 
 
-def create_fmu_container(configuration, output_filename):
+def create_fmu_container(configuration, output_filename, generation_datetime=datetime.now(pytz.utc).isoformat()):
     """ Create an FMU from nested FMUs (experimental)
 
         see tests/test_fmu_container.py for an example
@@ -204,7 +204,7 @@ def create_fmu_container(configuration, output_filename):
         system=configuration,
         modelName=model_name,
         description=configuration.description,
-        generationDateAndTime=datetime.now(pytz.utc).isoformat(),
+        generationDateAndTime=generation_datetime,
         fmpyVersion=fmpy.__version__
     )
 


### PR DESCRIPTION
If you want to achive reproducible builds, then having non-reproducible inputs in your build outputs is
a no-go.

This allows to pass in a datetime manually such that the default remains the same, but you could be passing a static time as well.

For legal reasons we're currently not accepting pull requests.

Please [create an issue](https://github.com/CATIA-Systems/FMPy/issues) if you have suggestions for improvements.
