### PR TITLE
Allow os.PathLike as path to extracted FMU in simulate_fmu()

### DIFF
--- a/fmpy/__init__.py
+++ b/fmpy/__init__.py
@@ -73,7 +73,7 @@ def supported_platforms(filename: Union[str, IO]):
     """
 
     # get the files within the FMU
-    if isinstance(filename, str) and os.path.isdir(filename):  # extracted FMU
+    if isinstance(filename, (str, os.PathLike)) and os.path.isdir(filename):  # extracted FMU
         names = []
         for dirpath, _, filenames in os.walk(filename):
             for name in filenames:

--- a/fmpy/model_description.py
+++ b/fmpy/model_description.py
@@ -423,7 +423,7 @@ def read_model_description(filename: Union[str, IO], validate: bool = True, vali
     # remember the original filename
     _filename = filename
 
-    if isinstance(filename, str) and os.path.isdir(filename):  # extracted FMU
+    if isinstance(filename, (str, os.PathLike)) and os.path.isdir(filename):  # extracted FMU
         filename = os.path.join(filename, 'modelDescription.xml')
         tree = etree.parse(filename)
     elif isinstance(filename, str) and os.path.isfile(filename) and filename.lower().endswith('.xml'):  # XML file


### PR DESCRIPTION
fixes #431