### PR TITLE
Use latest commit of JesseTG/rm in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: 'true'
-    - uses: JesseTG/rm@v1.0.3
+    - uses: JesseTG/rm@b0586af
       with:
         path: fmpy
     - uses: actions/download-artifact@v4


### PR DESCRIPTION
to silence deprecation warnings