### PR TITLE
Bump minimum required CMake version to 3.10

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.2)
+cmake_minimum_required (VERSION 3.10)
 
 project (FMPy)
 


### PR DESCRIPTION
to avoid deprecation warnings

fixes #620