### PR TITLE
remoting/client: create lockfile with explicit r+w

### DIFF
--- a/native/remoting/client_tcp.cpp
+++ b/native/remoting/client_tcp.cpp
@@ -214,7 +214,7 @@ fmi2Component fmi2Instantiate(fmi2String instanceName, fmi2Type fmuType, fmi2Str
         // create lock file
         const char *lockFilePath = tempnam(NULL, "");
 
-        int lockFile = open(lockFilePath, O_CREAT | O_EXCL);
+        int lockFile = open(lockFilePath, O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
 
         if (lockFile == -1) {
             s_logger(s_componentEnvironment, instanceName, fmi2Error, "error", "Failed to create lock file %s.", lockFilePath);


### PR DESCRIPTION
This patch was written before I noticed the legal notice: feel free to discard (but please do apply explicit `O_CREAT` params to the client remoting code; it would simplify the packaging effort for NixOS: https://github.com/NixOS/nixpkgs/pull/397658).

Note: I have not tested the remoting functionality with this patch, only that it builds.

Cheers.

-----

This fixes the compilation error below, which is triggered in hardened build environments (e.g. NixOS):

       > In file included from /nix/store/aaaaaaaa-glibc-2.40-66-dev/include/fcntl.h:341,
       >                  from /build/source/native/remoting/client_tcp.cpp:12:
       > In function ‘int open(const char*, int, ...)’,
       >     inlined from ‘void* fmi2Instantiate(fmi2String, fmi2Type, fmi2String, fmi2String, const fmi2CallbackFunctions*, fmi2Boolean, fmi2Boolean)’ at /build/source/native/remoting/client_tcp.cpp:217:28:
       > /nix/store/aaaaaaaa-glibc-2.40-66-dev/include/bits/fcntl2.h:52:31: error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
       >    52 |           __open_missing_mode ();
       >       |           ~~~~~~~~~~~~~~~~~~~~^~

In short: O_CREAT without explicit mode params may generate a file with suid/sgid. Error triggered by _FORTIFY_SOURCE. This commit explicitly creates the file with read/write permissions for the file owner.

Adopted from https://github.com/facebook/hhvm/issues/168

For legal reasons we're currently not accepting pull requests.

Please [create an issue](https://github.com/CATIA-Systems/FMPy/issues) if you have suggestions for improvements.
