### PR TITLE
Load FMI 1.0/2.0 binaries from FMI 3.0 platform-tuple directories

### DIFF
--- a/src/fmpy/__init__.py
+++ b/src/fmpy/__init__.py
@@ -111,18 +111,20 @@ def supported_platforms(filename: Union[str, IO]):
             break
 
     # check for *.so on Linux
-    for bitness, architecture in [('32', 'i686'), ('64', 'x86_64')]:
+    for bitness, architectures in [('32', {'i686'}), ('64', {'x86_64', 'aarch64'})]:
+        dirs = {'binaries/linux' + bitness} | {'binaries/' + a + '-linux' for a in architectures}
         for name in names:
             head, tail = os.path.split(name)
-            if head in {'binaries/linux' + bitness, 'binaries/' + architecture + '-linux'} and tail.endswith('.so'):
+            if head in dirs and tail.endswith('.so'):
                 platforms.append('linux' + bitness)
                 break
 
     # check for *.dll on Windows
-    for bitness, architecture in [('32', 'x86'), ('64', 'x86_64')]:
+    for bitness, architectures in [('32', {'x86'}), ('64', {'x86_64', 'aarch64'})]:
+        dirs = {'binaries/win' + bitness} | {'binaries/' + a + '-windows' for a in architectures}
         for name in names:
             head, tail = os.path.split(name)
-            if head in {'binaries/win' + bitness, 'binaries/' + architecture + '-windows'} and tail.endswith('.dll'):
+            if head in dirs and tail.endswith('.dll'):
                 platforms.append('win' + bitness)
                 break
 

--- a/src/fmpy/fmi1.py
+++ b/src/fmpy/fmi1.py
@@ -35,7 +35,7 @@ from ctypes import (
     Structure,
     CFUNCTYPE,
 )
-from . import free, freeLibrary, platform, sharedLibraryExtension, calloc
+from . import free, freeLibrary, platform, platform_tuple, sharedLibraryExtension, calloc
 
 
 fmi1Component = c_void_p
@@ -178,7 +178,17 @@ class _FMU(object):
         work_dir = os.getcwd()
 
         if libraryPath is None:
-            library_dir = os.path.join(unzipDirectory, "binaries", platform)
+            # FMI 2.0 only defines platform names for x86 and x86-64 (e.g.
+            # "darwin64"). On other architectures (e.g. Apple Silicon) FMUs use
+            # the FMI 3.0 platform tuple. Prefer the platform tuple, which is
+            # unambiguous about the architecture, and fall back to the legacy
+            # platform name (e.g. for a dual-architecture FMU, the legacy
+            # directory may contain a binary for a different architecture).
+            library_dir = os.path.join(unzipDirectory, "binaries", platform_tuple)
+            if not os.path.isfile(
+                os.path.join(library_dir, self.modelIdentifier + sharedLibraryExtension)
+            ):
+                library_dir = os.path.join(unzipDirectory, "binaries", platform)
             library_dir = os.path.abspath(library_dir)
             libraryPath = str(
                 os.path.join(library_dir, self.modelIdentifier + sharedLibraryExtension)


### PR DESCRIPTION
Resolves https://github.com/CATIA-Systems/FMPy/issues/395.

From the FMI 2.0.5 spec:

> The following names are standardized: for Windows: “win32”, “win64”, for Linux: “linux32”, “linux64”, for Macintosh: “darwin32”, “darwin64”, where "32" stands for "32-bit x86" and "64" for "64-bit x86" respectively.
> 
> For any other platforms the "platform tuples" defined in the FMI 3.0 Specification, 2.5.1.4.1. Platform Tuple Definition, or any updated "platform tuples" published by MAP FMI on fmi-standard.org, should be used.

This extends the work done in https://github.com/CATIA-Systems/FMPy/pull/636/ which applied to FMIv3 and `fmi_info()`/`dump()`/`validate_fmu()` but not the FMI 1.0 / 2.0 loader. As a bonus, add support for Windows AArch64 and Linux AArch64.

Note that the `supported_platforms()` returns e.g. `darwin64` even for `aarch64-darwin` which can cause [platform checks](https://github.com/CATIA-Systems/FMPy/blob/e8b71b702fb4a5b6b63db9ef934f6dbb29816be6/src/fmpy/simulation.py#L696-L699) to incorrectly pass on these platforms (e.g. when trying to run an x86-64 FMU on AArch64). However #636 has the same problem and fixing it touches quite a few more lines, so I left it as future work for now.

The patch set was generated with Claude Fable 5, after which I reviewed the changes in full.